### PR TITLE
Catch errors when accessing local options

### DIFF
--- a/autoload/nrrwrgn.vim
+++ b/autoload/nrrwrgn.vim
@@ -557,7 +557,10 @@ fun! <sid>GetOptions(opt) "{{{1
 	else
 		let result={}
 		for item in a:opt
-			exe "let result[item]=&l:".item
+			try
+				exe "let result[item]=&l:".item
+			catch
+			endtry
 		endfor
 	endif
 	return result


### PR DESCRIPTION
Hello,

NrrwRgn raises an error in console vim:

```
Error detected while processing function nrrwrgn#NrrwRgn..<SNR>36_NrwRgnWin..<SNR>36_GetOptions:
line    6:
E113: Unknown option: balloonexpr
E15: Invalid expression: &l:balloonexpr
```

This is because the +ballooneval feature is a GUI feature.

Following simple patch wraps &l:option access in try/catch.

Cheers,
guns
