### PR TITLE
README.md: Use <Leader> instead of '\'

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here is a short overview of the functionality provided by the plugin:
     :NRN	 - Disable Syncing the buffer content back
     :NRL	 - Reselect the last selected region and open it again in a narrowed window
 ####Visual mode commands:
-    \nr		 - Open the current visual selection in a new narrowed window
+    <Leader>nr		 - Open the current visual selection in a new narrowed window
 ####Scripting Functions:
     nrrwrgn#NrrwRgnStatus()   - Return a dict with all the status information for the current window
 


### PR DESCRIPTION
Hello,

The `\nr` example isn't correct for users not using the default leader key, so this fixes that. Thanks for the great plugin by the way :) 