### PR TITLE
Add short alias for WidenRegion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@ Here is a short overview of the functionality provided by the plugin:
 
 ### Ex commands:
 
-    :NR           - Open the selected region in a new narrowed window
-    :NW           - Open the current visual window in a new narrowed window
-    :WidenRegion  - (In the narrowed window) write the changes back to the original buffer.
-    :NRV          - Open the narrowed window for the region that was last visually selected.
-    :NUD          - (In a unified diff) open the selected diff in 2 Narrowed windows
-    :NRP          - Mark a region for a Multi narrowed window
-    :NRM          - Create a new Multi narrowed window (after :NRP) - experimental!
-    :NRS          - Enable Syncing the buffer content back (default on)
-    :NRN          - Disable Syncing the buffer content back
-    :NRL          - Reselect the last selected region and open it again in a narrowed window
+    :NR  - Open the selected region in a new narrowed window
+    :NW  - Open the current visual window in a new narrowed window
+    :WR  - (In the narrowed window) write the changes back to the original buffer.
+    :NRV - Open the narrowed window for the region that was last visually selected.
+    :NUD - (In a unified diff) open the selected diff in 2 Narrowed windows
+    :NRP - Mark a region for a Multi narrowed window
+    :NRM - Create a new Multi narrowed window (after :NRP) - experimental!
+    :NRS - Enable Syncing the buffer content back (default on)
+    :NRN - Disable Syncing the buffer content back
+    :NRL - Reselect the last selected region and open it again in a narrowed window
 
-You can append `!` to most commands to open the narrowed part in the current window instead of a new window.
+You can append `!` to most commands to open the narrowed part in the current window instead of a new window. In the case of `:WR`, appending `!` closes the narrowed window in addition to writing to the original buffer.
 
 ### Visual mode commands:
 

--- a/autoload/nrrwrgn.vim
+++ b/autoload/nrrwrgn.vim
@@ -831,6 +831,7 @@ endfun
 
 fun! <sid>SetupBufLocalCommands() abort "{{{1
 	com! -buffer -bang WidenRegion :call nrrwrgn#WidenRegion(<bang>0)
+	com! -buffer -bang WR :WidenRegion<bang><cr>
 	com! -buffer NRSyncOnWrite  :call nrrwrgn#ToggleSyncWrite(1)
 	com! -buffer NRNoSyncOnWrite :call nrrwrgn#ToggleSyncWrite(0)
 endfun

--- a/doc/NarrowRegion.txt
+++ b/doc/NarrowRegion.txt
@@ -67,7 +67,8 @@ This plugin defines the following commands:
                             split buffer but in the current window (works best
                             with 'hidden' set).
 
-                                                                *:WidenRegion*
+                                                         *:WidenRegion* *:WR*
+:WR[!]
 :WidenRegion[!]             This command is only available in the narrowed
                             scratch window. If the buffer has been modified,
                             the contents will be put back on the original


### PR DESCRIPTION
I like using `:NR!` to narrow the given range. I'd like to use `:WR!` to widen, instead of having to type out `:WidenRegion!`.