### PR TITLE
The WR command fix

### DIFF
--- a/autoload/nrrwrgn.vim
+++ b/autoload/nrrwrgn.vim
@@ -831,7 +831,7 @@ endfun
 
 fun! <sid>SetupBufLocalCommands() abort "{{{1
 	com! -buffer -bang WidenRegion :call nrrwrgn#WidenRegion(<bang>0)
-	com! -buffer -bang WR :WidenRegion<bang><cr>
+	com! -buffer -bang WR :WidenRegion<bang>
 	com! -buffer NRSyncOnWrite  :call nrrwrgn#ToggleSyncWrite(1)
 	com! -buffer NRNoSyncOnWrite :call nrrwrgn#ToggleSyncWrite(0)
 endfun


### PR DESCRIPTION
Had this issue: https://github.com/chrisbra/NrrwRgn/issues/78

romainl from #vim in freenode pointed out the `<cr>`, removing that fixes the issue.

Tested in Neovim 0.4.3