### PR TITLE
Confusion with buffer also on preceding tab

### DIFF
--- a/autoload/nrrwrgn.vim
+++ b/autoload/nrrwrgn.vim
@@ -765,6 +765,10 @@ fun! <sid>BufInTab(bufnr) abort "{{{1
 		" no tabpages present
 		return 1
 	endif
+	" Do not leave tab if buffer exists there
+	if !empty(filter(tabpagebuflist(), 'v:val == a:bufnr'))
+		return tabpagenr()
+	endif
 	for tab in range(1,tabpagenr('$'))
 		if !empty(filter(tabpagebuflist(tab), 'v:val == a:bufnr'))
 			return tab


### PR DESCRIPTION
If the buffer is also open on a preceding tab the BufWinLeave autocommand results in confusing action because always jumps away from the tab with the narrowed region.
The solution is to first check whether the corresponding buffer resides on the current tab in <sid>BufInTab.