### PR TITLE
Add `b:nrrw_aucmd_writepost` hook

### DIFF
--- a/autoload/nrrwrgn.vim
+++ b/autoload/nrrwrgn.vim
@@ -77,6 +77,9 @@ fun! <sid>SetupHooks() abort "{{{1
 	if exists("b:nrrw_aucmd_create")
 		let s:nrrw_aucmd["create"] = b:nrrw_aucmd_create
 	endif
+	if exists("b:nrrw_aucmd_writepost")
+		let s:nrrw_aucmd["writepost"] = b:nrrw_aucmd_writepost
+	endif
 	if exists("b:nrrw_aucmd_close")
 		let s:nrrw_aucmd["close"] = b:nrrw_aucmd_close
 	endif
@@ -243,6 +246,10 @@ fun! <sid>WriteNrrwRgn(...) abort "{{{1
 		endif
 		" prevent E315
 		call winrestview(_wsv)
+		" Execute "writepost" autocommands in narrowed buffer
+		if exists("b:nrrw_aucmd_writepost")
+		        exe b:nrrw_aucmd_writepost
+		endif
 	else
 		call <sid>StoreLastNrrwRgn(nrrw_instn)
 		" b:orig_buf might not exists (see issue #2)
@@ -1195,6 +1202,9 @@ fun! nrrwrgn#NrrwRgn(mode, ...) range  abort "{{{1
 	call <sid>SetOptions(local_options)
 	if has_key(s:nrrw_aucmd, "create")
 		exe s:nrrw_aucmd["create"]
+	endif
+	if has_key(s:nrrw_aucmd, "writepost")
+		let b:nrrw_aucmd_writepost = s:nrrw_aucmd["writepost"]
 	endif
 	if has_key(s:nrrw_aucmd, "close")
 		let b:nrrw_aucmd_close = s:nrrw_aucmd["close"]

--- a/doc/NarrowRegion.txt
+++ b/doc/NarrowRegion.txt
@@ -435,16 +435,20 @@ Note: These hooks are executed in the narrowed window (i.e. after creating the
 narrowed window and its content and before writing the changes back to the
 original buffer).
 
-A third hook *b:nrrw_aucmd_written* is provided, when the data is written back
-in the original window. This allows to execute scripts, whenever the data is
-written back in the original window. For example, consider you want to write
-the original buffer whenever the narrowed window is written back to the
-original window. You can therefore set: >
+Additional hooks *b:nrrw_aucmd_writepost* and *b:nrrw_aucmd_written* are
+provided, when the data is written back in the original window: the first one
+is executed in the narrowed window, while the second one in the original one
+(the one where the narrowed region was created from).  For example, consider
+you want the execute the command |:make| in the narrowed window, and also write
+the original buffer, whenever the narrowed window is written back to the
+original window. You therefore set: >
     
+    :let b:nrrw_aucmd_writepost = ':make'
     :let b:nrrw_aucmd_written = ':update'
 <
-This will write the original buffer, whenever it was modified after writing
-the changes from the narrowed window back.
+This will run |:make| in the narrowed window and also |:update| the original
+buffer, whenever it was modified after writing the changes from the narrowed
+window back.
 
 2.4 NrrwRgn functions                                    *NrrwRgn-func*
 ---------------------


### PR DESCRIPTION
My `BufWritePost` autocommands were not firing for the narrowed region, and after a little bit of digging I got to the conclusion that this had something to do with the fact that the plugin uses `BufWriteCmd` to sync data back into the original window, and that somehow that causes `BufWrite` and `BufWritePost` events from firing correctly (I am not an expert, so apologies if this analysis is incomplete).  Anyways, I was looking for a way to reinstate these events for the narrowed window, and the cleanest solution I came up with was to add an additional hook, `b:nrrw_aucmd_writepost`, executed in the narrowed window (and not in the original one a la `b:nrrw_aucmd_written`).

Anyways, let me know where you stand on getting these changes merged, and / or if you preferred I tackled the problem (I hope it's clear what I am trying to achieve), differently.

Ciao,
M.